### PR TITLE
fix: failing cql as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 0.9.1 - TBD
+
+### Fixed
+
+- Failing `query`-tool executions shown as success in traces
+
 ## Version 0.9.0 - 2026-08-10
 
 ### Added

--- a/srv/handlers/tools.js
+++ b/srv/handlers/tools.js
@@ -17,6 +17,12 @@ import { isTextMime } from "../../lib/agents/markdown/backends/mime-utils.js"
 
 const LOG = cds.log("agent")
 
+const unwrap = (result) => {
+  const text = result.content?.[0]?.text ?? ""
+  if (result.isError) throw new Error(text)
+  return text
+}
+
 /**
  * Reuses tool definitions and execution logic from @cap-js/mcp
  *
@@ -52,8 +58,7 @@ export function generateTools(srv, options = {}) {
         description: def.description,
         schema: def.inputSchema,
         func: async (args) => {
-          const result = await executeGenericReadTool(srv, entities, args, { log: LOG })
-          return result.content[0].text
+          return unwrap(await executeGenericReadTool(srv, entities, args, { log: LOG }))
         },
       }),
     )
@@ -69,8 +74,7 @@ export function generateTools(srv, options = {}) {
         description: def.description,
         schema: def.inputSchema,
         func: async (args) => {
-          const result = await executeDescribe(srv, entities, actions, args, { log: LOG })
-          return result.content[0].text
+          return unwrap(await executeDescribe(srv, entities, actions, args, { log: LOG }))
         },
       }),
     )
@@ -88,8 +92,7 @@ export function generateTools(srv, options = {}) {
             description: def.description,
             schema: def.inputSchema,
             func: async (args) => {
-              const result = await executePerActionTool(srv, name, action, args, { log: LOG })
-              return result.content[0].text
+              return unwrap(await executePerActionTool(srv, name, action, args, { log: LOG }))
             },
           }),
         )
@@ -102,8 +105,7 @@ export function generateTools(srv, options = {}) {
           description: def.description,
           schema: def.inputSchema,
           func: async (args) => {
-            const result = await executeCallActionTool(srv, actions, args, { log: LOG })
-            return result.content[0].text
+            return unwrap(await executeCallActionTool(srv, actions, args, { log: LOG }))
           },
         }),
       )

--- a/tests/samples/deep-agent/package.json
+++ b/tests/samples/deep-agent/package.json
@@ -7,7 +7,7 @@
     "@cap-js/agents": "file:../../../",
     "@cap-js/audit-logging": ">=1",
     "@cap-js/sqlite": "*",
-    "@cap-js/telemetry": "^1",
+    "@cap-js/telemetry": "^2",
     "@langchain/core": "^1",
     "@langchain/langgraph": "^1",
     "@sap-ai-sdk/langchain": "^2",


### PR DESCRIPTION
Before, we showed the following on malformed cql:

<img width="1157" height="592" alt="image" src="https://github.com/user-attachments/assets/be3fd80f-6e93-456d-a770-227fc01e906e" />
with the following output: 
<img width="810" height="132" alt="image" src="https://github.com/user-attachments/assets/47f7b550-108a-4621-8258-5ad697b71f03" />

With this change, we go to this:
<img width="1178" height="503" alt="image" src="https://github.com/user-attachments/assets/1f8ab4c5-3717-423f-bff0-eeee5384dfd5" />
<img width="804" height="167" alt="image" src="https://github.com/user-attachments/assets/008c645f-87ff-4bee-85dd-66adc8ef6549" />


Not a huge change as the LLM was fine with the semantic error message, but this might be needed for tracability