### PR TITLE
chore: remove push notification preview

### DIFF
--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -63,7 +63,6 @@
         height: 8px;
         border-radius: 50%;
         background: #4caf50;
-        margin-left: auto;
         flex-shrink: 0;
         transition: background 0.3s;
       }

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -402,13 +402,9 @@
     <header>
       <a class="back" id="back" title="Back to index">&#8592;</a>
       <h1>{{agentName}}</h1>
-      <label class="header-toggle" title="Stream tokens as they arrive">
+      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left:auto">
         <input type="checkbox" id="streamToggle" checked />
         Token Streaming
-      </label>
-      <label class="header-toggle" title="Deliver results via push notifications">
-        <input type="checkbox" id="push-mode" checked />
-        Push notifications
       </label>
       <div class="status-dot" id="dot"></div>
     </header>
@@ -445,10 +441,6 @@
       let streamingBubble = null
       let streamingText = ""
 
-      let pushMode = false
-      let pushSessionId = null
-      let pushEventSource = null
-
       const HISTORY_KEY = "chatHistory_" + AGENT_URL
       let inputHistory = JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]")
       let historyIndex = -1
@@ -461,31 +453,6 @@
           .filter((p) => p.kind === "text" || p.text)
           .map((p) => p.text)
           .join("")
-
-      // Push notification mode toggle
-      const pushModeCheckbox = document.getElementById("push-mode")
-      pushModeCheckbox.addEventListener("change", (e) => {
-        pushMode = e.target.checked
-        if (pushMode) {
-          pushSessionId = crypto.randomUUID()
-          const baseUrl =
-            window.location.origin + window.location.pathname.replace(/\/preview\/?$/, "")
-          const bridgeUrl = baseUrl + "/preview/push/" + pushSessionId
-          pushEventSource = new EventSource(bridgeUrl)
-          pushEventSource.onmessage = (e) => {
-            const task = JSON.parse(e.data)
-            handlePushNotification(task)
-          }
-        } else {
-          pushEventSource?.close()
-          pushEventSource = null
-          pushSessionId = null
-        }
-      })
-      pushModeCheckbox.dispatchEvent(new Event("change"))
-      window.addEventListener("beforeunload", () => {
-        pushEventSource?.close()
-      })
 
       prompt.addEventListener("input", () => {
         prompt.style.height = "auto"
@@ -609,7 +576,7 @@
             signal: abort.signal,
             body: JSON.stringify({
               jsonrpc: "2.0",
-              method: streamToggle.checked || pushMode ? "message/stream" : "message/send",
+              method: streamToggle.checked ? "message/stream" : "message/send",
               id: crypto.randomUUID(),
               params: {
                 message: {
@@ -619,33 +586,17 @@
                   contextId,
                   parts: [{ kind: "text", text: decision }],
                 },
-                ...(pushMode && pushSessionId
-                  ? {
-                      configuration: {
-                        pushNotificationConfig: {
-                          url:
-                            window.location.origin +
-                            window.location.pathname.replace(/\/preview\/?$/, "") +
-                            "/preview/push/" +
-                            pushSessionId,
-                          token: pushSessionId,
-                        },
-                      },
-                    }
-                  : {}),
               },
             }),
           })
 
-          if (streamToggle.checked || pushMode) {
+          if (streamToggle.checked) {
             await handleSSEResponse(resp)
           } else {
             const envelope = await resp.json()
             if (envelope.error) throw new Error(envelope.error.message || "Request failed")
             await handleResult(envelope.result)
           }
-
-          if (pushMode) statusText.textContent = "Waiting for push notification…"
         } catch (err) {
           if (err.name === "AbortError") return
           dot.className = "status-dot error"
@@ -689,24 +640,6 @@
         addMessage("agent", reply || "(no response)")
       }
 
-      function handlePushNotification(task) {
-        const state = task.status?.state
-        if (state === "working" || state === "submitted") {
-          // Only show working status updates when push notifications are active and agent is running
-          if (!pushMode || !busy) return
-          const text = partsToText(task.status?.message?.parts)
-          if (text) {
-            statusText.textContent = text
-            messages.scrollTop = messages.scrollHeight
-          }
-          return
-        }
-        // Terminal state: if streaming is on it already rendered the result — skip
-        if (streamToggle.checked) return
-        setBusy(false)
-        handleResult(task)
-      }
-
       async function send() {
         const text = prompt.value.trim()
         if (!text || busy) return
@@ -730,7 +663,7 @@
         streamingBubble = null
         streamingText = ""
 
-        const useStream = streamToggle.checked || pushMode
+        const useStream = streamToggle.checked
         try {
           const resp = await fetch(AGENT_URL, {
             method: "POST",
@@ -747,20 +680,6 @@
                   ...(contextId ? { contextId } : {}),
                   parts: [{ kind: "text", text }],
                 },
-                ...(pushMode && pushSessionId
-                  ? {
-                      configuration: {
-                        pushNotificationConfig: {
-                          url:
-                            window.location.origin +
-                            window.location.pathname.replace(/\/preview\/?$/, "") +
-                            "/preview/push/" +
-                            pushSessionId,
-                          token: pushSessionId,
-                        },
-                      },
-                    }
-                  : {}),
               },
             }),
           })
@@ -782,52 +701,6 @@
         } finally {
           setBusy(false)
           prompt.focus()
-        }
-      }
-
-      async function sendPushMode(text) {
-        const baseUrl =
-          window.location.origin + window.location.pathname.replace(/\/preview\/?$/, "")
-        const webhookUrl = baseUrl + "/preview/push/" + pushSessionId
-
-        try {
-          const resp = await fetch(AGENT_URL, {
-            method: "POST",
-            headers: { "Content-Type": "application/json", ...authHeaders() },
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              method: "message/send",
-              id: crypto.randomUUID(),
-              params: {
-                message: {
-                  role: "user",
-                  messageId: crypto.randomUUID(),
-                  ...(contextId ? { contextId } : {}),
-                  parts: [{ kind: "text", text }],
-                },
-                configuration: {
-                  pushNotificationConfig: {
-                    url: webhookUrl,
-                    token: pushSessionId,
-                  },
-                },
-              },
-            }),
-          })
-
-          const envelope = await resp.json()
-          if (envelope.error) throw new Error(envelope.error.message || "Request failed")
-
-          const task = envelope.result
-          if (task?.id) activeTaskId = task.id
-          if (task?.contextId) contextId = task.contextId
-
-          statusText.textContent = "Waiting for push notification…"
-        } catch (err) {
-          dot.className = "status-dot error"
-          addMessage("error", "⚠ " + (err.message || String(err)))
-          setBusy(false)
-          setTimeout(() => (dot.className = "status-dot"), 3000)
         }
       }
 
@@ -889,13 +762,11 @@
         // Track contextId from status-updates
         if (event.contextId) contextId = event.contextId
 
-        // Non-final status-update with message → show as progress text only when push is on and streaming is off
+        // Non-final status-update with message → show as progress text from streaming
         if (
           event.kind === "status-update" &&
           !event.final &&
-          event.status?.message &&
-          pushMode &&
-          !streamToggle.checked
+          event.status?.message
         ) {
           const text = partsToText(event.status.message.parts)
           if (text) {
@@ -948,8 +819,6 @@
 
         // Status update with final=true means terminal state
         if (event.kind === "status-update" && event.final) {
-          // When push-only (no streaming): push notification handles the final render
-          if (pushMode && !streamToggle.checked) return null
           return {
             id: event.taskId || activeTaskId,
             contextId: event.contextId || contextId,

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -401,9 +401,9 @@
     <header>
       <a class="back" id="back" title="Back to index">&#8592;</a>
       <h1>{{agentName}}</h1>
-      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left:auto">
+      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left: auto">
         <input type="checkbox" id="streamToggle" checked />
-        Token Streaming
+        Streaming
       </label>
       <div class="status-dot" id="dot"></div>
     </header>
@@ -762,11 +762,7 @@
         if (event.contextId) contextId = event.contextId
 
         // Non-final status-update with message → show as progress text from streaming
-        if (
-          event.kind === "status-update" &&
-          !event.final &&
-          event.status?.message
-        ) {
+        if (event.kind === "status-update" && !event.final && event.status?.message) {
           const text = partsToText(event.status.message.parts)
           if (text) {
             statusText.textContent = text

--- a/lib/preview/preview.js
+++ b/lib/preview/preview.js
@@ -10,8 +10,6 @@ const _require = createRequire(import.meta.url)
 const _markedPath = join(dirname(_require.resolve("marked/package.json")), "lib", "marked.umd.js")
 const _markedJs = readFileSync(_markedPath, "utf-8")
 
-const sessions = new Map() // sessionId → Set<res>
-
 export default function preview(agentName) {
   const router = express.Router()
 
@@ -42,40 +40,6 @@ export default function preview(agentName) {
     res.setHeader("Content-Type", "application/javascript; charset=utf-8")
     res.setHeader("Cache-Control", "public, max-age=86400")
     res.send(_markedJs)
-  })
-
-  // SSE bridge — browser subscribes here to receive relayed push notifications
-  router.get("/push/:sessionId", (req, res) => {
-    const { sessionId } = req.params
-    res.setHeader("Content-Type", "text/event-stream")
-    res.setHeader("Cache-Control", "no-cache")
-    res.setHeader("Connection", "keep-alive")
-    res.setHeader("X-Accel-Buffering", "no")
-    res.flushHeaders()
-
-    if (!sessions.has(sessionId)) sessions.set(sessionId, new Set())
-    sessions.get(sessionId).add(res)
-
-    req.on("close", () => {
-      sessions.get(sessionId)?.delete(res)
-      if (sessions.get(sessionId)?.size === 0) sessions.delete(sessionId)
-    })
-  })
-
-  // Webhook receiver — SDK posts task updates here
-  router.post("/push/:sessionId", express.json(), (req, res) => {
-    const { sessionId } = req.params
-    const token = req.headers["x-a2a-notification-token"]
-    if (token && token !== sessionId) {
-      res.status(403).end()
-      return
-    }
-    const subscribers = sessions.get(sessionId)
-    if (subscribers) {
-      const data = `data: ${JSON.stringify(req.body)}\n\n`
-      for (const sub of subscribers) sub.write(data)
-    }
-    res.status(200).end()
   })
 
   return router


### PR DESCRIPTION
The push notifications in the preview were only used for the status updates which are now received through streaming. They worked via a webhook bridge in the same backend app which is not a typical scenario -> removing it. 