### PR TITLE
fix: remove entities from index

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -31,7 +31,7 @@ const cls_fields = (cds.env.log.cls_custom_fields ??= [])
 if (!cls_fields.includes("agent.task.id")) cls_fields.push("agent.task.id")
 if (!cls_fields.includes("agent.context.id")) cls_fields.push("agent.context.id")
 
-cds.on("bootstrap", () => {
+cds.on("bootstrap", (app) => {
   const providers = {
     ["llm-mock"]: {},
     anthropic: {
@@ -57,6 +57,24 @@ cds.on("bootstrap", () => {
       s.model = providers[provider][model] ?? model
     }
   }
+
+  const profiles = cds.env.profiles || []
+  const isDev = profiles.includes("development") && !profiles.includes("production")
+  if (!isDev) return
+  if (cds.env.server?.index === false) return
+
+  const AGENT_BLOCK = /(<div id="[^"]+-agent">[\s\S]*?<\/h3>)[\s\S]*?<\/ul>\s*<\/div>/g
+
+  app.get("/", (_req, res, next) => {
+    const origSend = res.send.bind(res)
+    res.send = (body) => {
+      if (typeof body === "string") {
+        body = body.replace(AGENT_BLOCK, (_m, head) => `${head}\n      </div>`)
+      }
+      return origSend(body)
+    }
+    next()
+  })
 })
 
 cds.on("serving", (srv) => {


### PR DESCRIPTION
### fix: Remove Agent Entities from Index Page in Development

This PR adds middleware to strip agent-related entity listings from the CDS index page (`/`) in non-production development environments.

**What changed:**

In `cds-plugin.js`, the `bootstrap` event handler is updated to receive the Express `app` instance. After resolving LLM provider/model configurations, new logic is added to:

1. Detect if the current environment is **development-only** (not production).
2. Respect the `cds.env.server.index` flag — if the index is disabled, skip the middleware.
3. Register a middleware on `GET /` that intercepts the response and strips the entity list items from any `<div>` blocks corresponding to agent services, leaving only the section heading (`<h3>`) intact.

This prevents agent-internal entities from being exposed/listed on the CAP index page during local development.

**Category:** 🐛 Bug Fix

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `5bf97f30-9586-11f1-823f-0161d323b29c`
</details>
