### PR TITLE
chore(ci): reduce debug logs in hybrid test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
       - run: npm i --legacy-peer-deps
       - run: cds v -i
       - run: npm run test
+        env:
+          DEBUG: ${{ runner.debug == '1' && 'agent' || '' }}
 
   test-hybrid:
     runs-on: ubuntu-latest
@@ -82,3 +84,5 @@ jobs:
       - run: cds v -i
       - run: cds bind -2 joule-cap-proxy -o package.json
       - run: npm run test:hybrid
+        env:
+          DEBUG: ${{ runner.debug == '1' && 'agent' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - run: cds v -i
       - run: npm run test
         env:
-          DEBUG: ${{ runner.debug == '1' && 'agent' || '' }}
+          CDS_ENV: ${{ runner.debug == '1' && 'tracing' || '' }}
 
   test-hybrid:
     runs-on: ubuntu-latest
@@ -85,4 +85,4 @@ jobs:
       - run: cds bind -2 joule-cap-proxy -o package.json
       - run: npm run test:hybrid
         env:
-          DEBUG: ${{ runner.debug == '1' && 'agent' || '' }}
+          CDS_ENV: ${{ runner.debug == '1' && 'tracing' || '' }}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:cds8": "CDS_ENV=test npx vitest run --config vitest.config.js",
     "pretest:cds8": "npm pkg set 'overrides.@sap/cds=^8' 'overrides.@cap-js/sqlite=^1' 'overrides.@cap-js/hana=^1' 'overrides.@sap/cds-mtxs=^2' 'overrides.express=^4' && npm pkg set 'devDependencies.@sap/cds=^8' 'devDependencies.@cap-js/sqlite=^1' 'devDependencies.@cap-js/cds-test=>0' 'peerDependencies.@sap/cds=^8' && npm pkg delete 'devDependencies.@cap-js/hana' 'devDependencies.@sap/cds-mtxs' && rm -rf node_modules && npm i --legacy-peer-deps",
     "posttest:cds8": "git checkout package.json && rm -rf node_modules && npm i --legacy-peer-deps",
-    "test:hybrid": "CDS_ENV=test,hybrid,tracing cds bind --exec -- npx vitest run --config vitest.config.hybrid.js",
+    "test:hybrid": "cds bind --profile test,hybrid --exec -- npx vitest run --config vitest.config.hybrid.js",
     "test:mtx": "CDS_ENV=test npx vitest run --config vitest.config.js tests/integration/mtx.test.js",
     "watch:sample": "cds w tests/samples/bookshop",
     "watch:hybrid": "DEBUG=agent cds bind --exec -- cds w tests/samples/bookshop",

--- a/tests/samples/bookshop/package.json
+++ b/tests/samples/bookshop/package.json
@@ -56,21 +56,6 @@
         "audit-log": {
           "outbox": false,
           "kind": "audit-log-to-console"
-        },
-        "telemetry": {
-          "kind": "telemetry-to-console",
-          "tracing": {
-            "exporter": {
-              "module": "@cap-js/telemetry",
-              "class": "ConsoleSpanExporter"
-            }
-          },
-          "metrics": {
-            "exporter": {
-              "module": "@cap-js/telemetry",
-              "class": "ConsoleMetricExporter"
-            }
-          }
         }
       },
       "[tracing]": {


### PR DESCRIPTION
We currently produce 30k lines of logs in the hybrid test, maybe this can be muted a bit.

Possible compromise: only show the `tracing` profile telemetry logs if the run was (re-)started with debug logging:
<img width="630" height="279" alt="Screenshot 2026-08-11 at 17 39 39" src="https://github.com/user-attachments/assets/334589c1-6873-4d15-b13f-dac5d43a5ec8" />
