### PR TITLE
fix: tool throwing for deepagents

### DIFF
--- a/lib/telemetry/tool-tracing.js
+++ b/lib/telemetry/tool-tracing.js
@@ -57,11 +57,26 @@ export function _patchToolsProto(proto) {
       try {
         const result = await original.call(this, args, config)
         const duration = Date.now() - t0
+
+        const semanticError = result?.artifact?.isError === true
+        const outcome = semanticError ? "error" : "success"
+        const outputs = result?.content ?? result
+
         if (span) {
-          span.setAttribute("gen_ai.tool.call.outcome", "success")
-          span.setStatus({ code: 1 })
-          const outputs = result.content ?? result
-          setSpanAttrs(span, mlflowAttrs("TOOL", { outputs }))
+          span.setAttribute("gen_ai.tool.call.outcome", outcome)
+          if (semanticError) {
+            const msg = typeof outputs === "string" ? outputs : "tool returned isError"
+            span.setAttribute("error.type", "Error")
+            span.setStatus({ code: 2, message: msg })
+            span.addEvent("exception", {
+              "exception.type": "Error",
+              "exception.message": msg,
+            })
+            setSpanAttrs(span, mlflowAttrs("TOOL", { outputs: { error: msg } }))
+          } else {
+            span.setStatus({ code: 1 })
+            setSpanAttrs(span, mlflowAttrs("TOOL", { outputs }))
+          }
           if (LOG._debug) {
             span.setAttribute("gen_ai.tool.call.result", outputs)
           }
@@ -71,21 +86,23 @@ export function _patchToolsProto(proto) {
           "sap.tenantId": cds.context?.tenant || "anonymous",
           "agent.service": config?.configurable?._service || cds.context?.["agent.service"],
           tool: toolName,
-          outcome: "success",
+          outcome,
         })
 
         // Audit: record tool invocation
         const taskId = config?.configurable?._taskId || cds.context?.["agent.task.id"]
         if (taskId) {
-          const resultStr = typeof result === "string" ? result : JSON.stringify(result)
+          const resultStr = typeof outputs === "string" ? outputs : JSON.stringify(outputs)
           audit("ToolInvocation", {
             data: {
               taskId,
               service: config?.configurable?._service || cds.context?.["agent.service"],
               tool: toolName,
               args,
-              outcome: "success",
-              result: resultStr?.slice(0, 2000),
+              outcome,
+              ...(semanticError
+                ? { error: resultStr?.slice(0, 2000) }
+                : { result: resultStr?.slice(0, 2000) }),
               duration,
             },
           })

--- a/srv/handlers/tools.js
+++ b/srv/handlers/tools.js
@@ -19,8 +19,7 @@ const LOG = cds.log("agent")
 
 const unwrap = (result) => {
   const text = result.content?.[0]?.text ?? ""
-  if (result.isError) throw new Error(text)
-  return text
+  return [text, { isError: result.isError === true }]
 }
 
 /**
@@ -57,6 +56,7 @@ export function generateTools(srv, options = {}) {
         name: def.name,
         description: def.description,
         schema: def.inputSchema,
+        responseFormat: "content_and_artifact",
         func: async (args) => {
           return unwrap(await executeGenericReadTool(srv, entities, args, { log: LOG }))
         },
@@ -73,6 +73,7 @@ export function generateTools(srv, options = {}) {
         name: def.name,
         description: def.description,
         schema: def.inputSchema,
+        responseFormat: "content_and_artifact",
         func: async (args) => {
           return unwrap(await executeDescribe(srv, entities, actions, args, { log: LOG }))
         },
@@ -91,6 +92,7 @@ export function generateTools(srv, options = {}) {
             name: def.name,
             description: def.description,
             schema: def.inputSchema,
+            responseFormat: "content_and_artifact",
             func: async (args) => {
               return unwrap(await executePerActionTool(srv, name, action, args, { log: LOG }))
             },
@@ -104,6 +106,7 @@ export function generateTools(srv, options = {}) {
           name: def.name,
           description: def.description,
           schema: def.inputSchema,
+          responseFormat: "content_and_artifact",
           func: async (args) => {
             return unwrap(await executeCallActionTool(srv, actions, args, { log: LOG }))
           },


### PR DESCRIPTION
Back to not throwing, but using the responseFormat `content_and_artifact`. MLFlow looks exactly the same, just removed the stacktrace, it was anyways always the same.

<img width="3134" height="405" alt="image" src="https://github.com/user-attachments/assets/a88f8219-414d-45f5-9543-004209f31d28" />
<img width="1028" height="291" alt="image" src="https://github.com/user-attachments/assets/075eda4b-87dd-47e7-83d2-218c47f1b5f1" />
