### PR TITLE
chore: hide streaming toggle

### DIFF
--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -404,7 +404,12 @@
     <header>
       <a class="back" id="back" title="Back to index">&#8592;</a>
       <h1>{{agentName}}</h1>
-      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left: auto" hidden>
+      <label
+        class="header-toggle"
+        title="Stream tokens as they arrive"
+        style="margin-left: auto"
+        hidden
+      >
         <input type="checkbox" id="streamToggle" hidden />
         Streaming
       </label>

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -51,6 +51,9 @@
         user-select: none;
         flex-shrink: 0;
       }
+      .header-toggle[hidden] {
+        display: none;
+      }
       .header-toggle input[type="checkbox"] {
         accent-color: #7fbce8;
         width: 14px;
@@ -401,8 +404,8 @@
     <header>
       <a class="back" id="back" title="Back to index">&#8592;</a>
       <h1>{{agentName}}</h1>
-      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left: auto">
-        <input type="checkbox" id="streamToggle" checked />
+      <label class="header-toggle" title="Stream tokens as they arrive" style="margin-left: auto" hidden>
+        <input type="checkbox" id="streamToggle" hidden />
         Streaming
       </label>
       <div class="status-dot" id="dot"></div>


### PR DESCRIPTION
## chore: Hide Streaming Toggle in Chat Preview UI

### Description

This change hides the streaming toggle control from the chat preview header. The toggle element and its checkbox are now hidden using the `hidden` HTML attribute, and a corresponding CSS rule ensures `display: none` is applied to `.header-toggle[hidden]` elements.

### Changes

- **`lib/preview/chat.html`**:
  - Added CSS rule `.header-toggle[hidden] { display: none; }` to properly handle the hidden state.
  - Added `hidden` attribute to the `<label class="header-toggle">` element and its inner `<input type="checkbox" id="streamToggle">`.

### Category

🧹 **Chore**

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.25` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Output Template: Repository PR Template
- Correlation ID: `e1afd050-9628-11f1-94fd-c94a08a049a9`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
