### PR TITLE
fix: preview for multi turn

### DIFF
--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -616,6 +616,9 @@
       }
 
       async function handleResult(result) {
+        if (result?.contextId) contextId = result.contextId
+        if (result?.id) activeTaskId = result.id
+
         const state = result?.status?.state ?? result?.state
         const taskId = result?.id ?? result?.taskId
 


### PR DESCRIPTION
## Fix: Preview for Multi-Turn Conversations

This change fixes the preview chat interface to correctly handle multi-turn conversation flows in the A2A protocol.

### What Changed

In `lib/preview/chat.html`, the `handleResult` function now captures and persists two important identifiers from the server response:

- **`contextId`**: Stored from the result to maintain conversation context across multiple turns
- **`activeTaskId`**: Stored from the result's `id` field to track the current active task

These values were previously not being updated when a result was received, which would cause issues when the conversation required multiple turns (e.g., when the server responds with `input-required` state and the client needs to continue the interaction with the same context and task references).

### Category

🐛 **Bug Fix**

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `86a393d0-9660-11f1-8e72-d5b1f11a2b1d`
- Output Template: Repository PR Template
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
