### PR TITLE
ci: run test.yml with read-only permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cap-js/agents/security/code-scanning/1](https://github.com/cap-js/agents/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/test.yml` so all jobs inherit least-privilege defaults.  
Best single fix: add:

```yml
permissions:
  contents: read
```

immediately after the `on:` trigger block (before `jobs:`). This satisfies CodeQL’s recommendation and preserves current behavior since the workflow appears to only need repository read access for checkout and testing.

No imports, methods, or dependencies are needed; only YAML workflow configuration is changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
