### PR TITLE
chore: change log level + adjust scope to agents

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 import { patchLangChain } from "./lib/telemetry/tracing.js"
 import cds_compile_to_a2a from "./lib/compile.js"
 import registerDefaultAgentHandlers from "./srv/handlers/index.js"

--- a/lib/agents/markdown/deep-agent.js
+++ b/lib/agents/markdown/deep-agent.js
@@ -1,7 +1,7 @@
 import cds from "@sap/cds"
 const { fs, path } = cds.utils
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Auto-build a `deepagents` graph from the convention-resolved agent directory.

--- a/lib/agents/middleware/content-filter.js
+++ b/lib/agents/middleware/content-filter.js
@@ -7,7 +7,7 @@ import { toSdkFilterFormat } from "../../../lib/models/aicore.js"
 import { audit } from "../../utils/utils.js"
 import { INSTRUMENTED } from "../../telemetry/tracing.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Extract HTTP status and response data from a wrapped AI SDK error wrapped

--- a/lib/agents/quota-enforcer-at-start.js
+++ b/lib/agents/quota-enforcer-at-start.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const tasks = () => cds.model.definitions["cap.agent.Tasks"]
 

--- a/lib/agents/summarize-on-timeout.js
+++ b/lib/agents/summarize-on-timeout.js
@@ -2,7 +2,7 @@ import cds from "@sap/cds"
 import { HumanMessage } from "@langchain/core/messages"
 import { short } from "../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const DEFAULT_TIMEOUT = 10_000
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ import { short, audit } from "./utils/utils.js"
 import { partsToText } from "./utils/message-handling.js"
 import * as metrics from "./telemetry/metrics.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 // SSE wire-format helpers, mirroring @a2a-js/sdk's sse_utils so the adapter
 // streams message/stream responses identically to the SDK's reference

--- a/lib/models/aicore.js
+++ b/lib/models/aicore.js
@@ -5,7 +5,7 @@ import { circuitBreaker, timeout } from "@sap-cloud-sdk/resilience"
 import { SystemMessage, ToolMessage, HumanMessage, AIMessage } from "@langchain/core/messages"
 import { ms4 } from "../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 class _InstrumentedOrchestrationClient extends OrchestrationClient {
   constructor(name, options) {

--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -5,7 +5,7 @@ import os from 'node:os'
 import cds from '@sap/cds'
 
 const HOME = os.homedir() || process.env.HOME || process.env.USERPROFILE
-const LOG = cds.log('agent')
+const LOG = cds.log('agents')
 
 /**
  * `cds.connect.to` compliant langchain model

--- a/lib/protocol/agent-card.js
+++ b/lib/protocol/agent-card.js
@@ -12,7 +12,7 @@ import {
 
 const require = createRequire(import.meta.url)
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Check if push notifications are enabled via cds.agents.pushNotifications config.
@@ -245,11 +245,12 @@ function generateAgentCard(srv, options = {}, resolved = {}) {
     const cardMeta = parseAgentCardFile(agentCardPath)
     if (cardMeta) {
       const card = buildAgentCardFromCardFile(cardMeta, null, srv, servicePath, streaming)
-      LOG.debug("Generated agent card from @agent.card annotation", {
-        service: srv.name,
-        path: agentCardPath,
-        skills: card.skills.length,
-      })
+      LOG._trace &&
+        LOG.debug("Generated agent card from @agent.card annotation", {
+          service: srv.name,
+          path: agentCardPath,
+          skills: card.skills.length,
+        })
       return applyFileIOCapability(card)
     }
     LOG.warn("Agent card file not found or invalid YAML, falling back", {
@@ -265,28 +266,31 @@ function generateAgentCard(srv, options = {}, resolved = {}) {
     const cardMeta = parseAgentCardMd(agentDir)
     if (cardMeta) {
       const card = buildAgentCardFromCardFile(cardMeta, agentMeta, srv, servicePath, streaming)
-      LOG.debug("Generated agent card from AGENT_CARD.md", {
-        service: srv.name,
-        skills: card.skills.length,
-      })
+      LOG._trace &&
+        LOG.debug("Generated agent card from AGENT_CARD.md", {
+          service: srv.name,
+          skills: card.skills.length,
+        })
       return applyFileIOCapability(card)
     }
 
     // Priority 3: Scan skills/ directory
     const card = buildAgentCardFromSkills(agentDir, agentMeta, srv, servicePath, streaming)
-    LOG.debug("Generated agent card from skills/", {
-      service: srv.name,
-      skills: card.skills.length,
-    })
+    LOG._trace &&
+      LOG.debug("Generated agent card from skills/", {
+        service: srv.name,
+        skills: card.skills.length,
+      })
     return applyFileIOCapability(card)
   }
 
   // Priority 4: CDS model (agentify mode)
   const card = buildAgentCardFromModel(srv, servicePath, streaming)
-  LOG.debug("Generated agent card from CDS model", {
-    service: srv.name,
-    skills: card.skills.length,
-  })
+  LOG._trace &&
+    LOG.debug("Generated agent card from CDS model", {
+      service: srv.name,
+      skills: card.skills.length,
+    })
   return applyFileIOCapability(card)
 }
 

--- a/lib/protocol/persistence/checkpoint-saver.js
+++ b/lib/protocol/persistence/checkpoint-saver.js
@@ -7,7 +7,7 @@ import {
   getCheckpointId,
 } from "@langchain/langgraph-checkpoint"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const toUtf8String = (bytes) => Buffer.from(bytes).toString("utf-8")
 
@@ -138,7 +138,7 @@ export class CdsCheckpointSaver extends BaseCheckpointSaver {
       }
     }
 
-    LOG.debug("Checkpoint loaded", { thread_id, checkpoint_id: actualCheckpointId })
+    LOG._trace && LOG.debug("Checkpoint loaded", { thread_id, checkpoint_id: actualCheckpointId })
     return tuple
   }
 
@@ -170,7 +170,7 @@ export class CdsCheckpointSaver extends BaseCheckpointSaver {
       createdBy: resolveUserId(),
     })
 
-    LOG.debug("Checkpoint saved", { thread_id, checkpoint_id: checkpoint.id })
+    LOG._trace && LOG.debug("Checkpoint saved", { thread_id, checkpoint_id: checkpoint.id })
 
     return {
       configurable: {

--- a/lib/protocol/persistence/file-store.js
+++ b/lib/protocol/persistence/file-store.js
@@ -1,7 +1,7 @@
 import { Readable } from "node:stream"
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Resolve the user id used to scope input-file reads.

--- a/lib/protocol/persistence/push-notification-store.js
+++ b/lib/protocol/persistence/push-notification-store.js
@@ -1,7 +1,7 @@
 import cds from "@sap/cds"
 import { isAllowedDomain } from "../../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const CONFIGS = "cap.agent.PushNotificationConfigs"
 

--- a/lib/protocol/persistence/task-store.js
+++ b/lib/protocol/persistence/task-store.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const TASKS = "cap.agent.Tasks"
 
@@ -31,17 +31,17 @@ export class CdsTaskStore {
         })
     }
 
-    LOG.debug("Task saved", { taskId: task.id, state: task.status?.state })
+    LOG._trace && LOG.debug("Task saved", { taskId: task.id, state: task.status?.state })
   }
 
   async load(taskId) {
     const row = await SELECT.one.from(TASKS).where({ taskId, createdBy: cds.context.user.id })
     if (!row) {
-      LOG.debug("Task not found", { taskId })
+      LOG._trace && LOG.debug("Task not found", { taskId })
       return undefined
     }
 
-    LOG.debug("Task loaded", { taskId, state: row.state })
+    LOG._trace && LOG.debug("Task loaded", { taskId, state: row.state })
     return JSON.parse(row.data)
   }
 }

--- a/lib/protocol/push-notification-sender.js
+++ b/lib/protocol/push-notification-sender.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * CDS-based push notification sender with:

--- a/lib/telemetry/active-users.js
+++ b/lib/telemetry/active-users.js
@@ -2,7 +2,7 @@ import cds from "@sap/cds"
 import * as metrics from "./metrics.js"
 import { ms4 } from "../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 const TASKS = "cap.agent.Tasks"
 
 /** Cached active users data — updated by computeActiveUsers(), reported by gauge callback */

--- a/lib/telemetry/chat-tracing.js
+++ b/lib/telemetry/chat-tracing.js
@@ -3,7 +3,7 @@ import * as metrics from "./metrics.js"
 import { mlflowAttrs, setSpanAttrs } from "./mlflow.js"
 import { audit } from "../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const PATCHED = Symbol.for("@cap-js/agents:patched")
 const SPAN_KIND_CLIENT = 3

--- a/lib/telemetry/mlflow.js
+++ b/lib/telemetry/mlflow.js
@@ -180,7 +180,7 @@ export class RoutingSpanProcessor {
 export async function setupMlflowExporter() {
   if (!cds.env.agents?.mlflow) return
 
-  const LOG = cds.log("agent")
+  const LOG = cds.log("agents")
   try {
     const creds = cds.env.requires?.mlflow?.credentials || {}
     const host = creds.MLFLOW_HOST

--- a/lib/telemetry/tool-tracing.js
+++ b/lib/telemetry/tool-tracing.js
@@ -3,7 +3,7 @@ import * as metrics from "./metrics.js"
 import { mlflowAttrs, setSpanAttrs } from "./mlflow.js"
 import { audit } from "../utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /** Symbol marking our own instrumented classes — patch skips these */
 const INSTRUMENTED = Symbol.for("@cap-js/agents:instrumented")

--- a/lib/telemetry/tracing.js
+++ b/lib/telemetry/tracing.js
@@ -2,7 +2,7 @@ import cds from "@sap/cds"
 import * as metrics from "./metrics.js"
 import { mlflowAttrs, setSpanAttrs } from "./mlflow.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 // ─── Patching ────────────────────────────────────────────────────────────────
 

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 const { path, fs } = cds.utils
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Mirrors CAP's internal slug rules used for service path generation.

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -97,7 +97,7 @@ export function audit(event, data) {
       }),
     )
     .catch((err) => {
-      const LOG = cds.log("agent|audit")
+      const LOG = cds.log("agents|audit")
       LOG.warn("audit emit failed", { event, error: err.message })
     })
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:hybrid": "CDS_ENV=test,hybrid,tracing cds bind --exec -- npx vitest run --config vitest.config.hybrid.js",
     "test:mtx": "CDS_ENV=test npx vitest run --config vitest.config.js tests/integration/mtx.test.js",
     "watch:sample": "cds w tests/projects/bookshop",
-    "watch:hybrid": "DEBUG=agent cds bind --exec -- cds w tests/projects/bookshop",
+    "watch:hybrid": "DEBUG=agents cds bind --exec -- cds w tests/projects/bookshop",
     "watch:with-claude": "cds w tests/projects/bookshop --profile with-claude",
     "watch:deep-agent": "cds w tests/projects/deep-agent --profile hybrid",
     "prettier": "npx -y prettier@3 --write .",

--- a/srv/graph-cache.js
+++ b/srv/graph-cache.js
@@ -1,7 +1,7 @@
 import cds from "@sap/cds"
 import crypto from "crypto"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Compute a stable hash key from cds.context.features.

--- a/srv/handlers/graph-executor.js
+++ b/srv/handlers/graph-executor.js
@@ -7,7 +7,7 @@ import { CdsFileStore } from "../../lib/protocol/persistence/file-store.js"
 import { formatFileSize, sanitizeFilename } from "./tools.js"
 import { convertUsageData } from "../../lib/telemetry/chat-tracing.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Thrown when a task execution is aborted (client disconnect or tasks/cancel).

--- a/srv/handlers/index.js
+++ b/srv/handlers/index.js
@@ -4,7 +4,7 @@ import { buildSystemPrompt } from "./system-prompt.js"
 import buildMiddleware from "../../lib/agents/middleware/index.js"
 import { partsToText } from "../../lib/utils/message-handling.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Register default event handlers for agent graph building on an @agent service.

--- a/srv/handlers/mcp-tools.js
+++ b/srv/handlers/mcp-tools.js
@@ -3,7 +3,7 @@ import { MultiServerMCPClient } from "@langchain/mcp-adapters"
 import { generateTools } from "./tools.js"
 import { toolName } from "../../lib/utils/utils.js"
 
-const LOG = cds.log("agent:mcp")
+const LOG = cds.log("agents:mcp")
 
 /**
  * Resolve URL and HTTP headers for a BTP destination using the Cloud SDK.

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -4,7 +4,7 @@ import { z } from "zod"
 import { LangGraphExecutor } from "../langgraph-executor-srv.js"
 import { toolName } from "../../lib/utils/utils.js"
 
-const LOG = cds.log("agent:sub-agents")
+const LOG = cds.log("agents:sub-agents")
 
 /**
  * Extract text and file parts from an A2A response (task or message).

--- a/srv/handlers/tools.js
+++ b/srv/handlers/tools.js
@@ -15,7 +15,7 @@ import { getFilteredEntities, getFilteredActions } from "../../lib/utils/utils.j
 import { isTextMime } from "../../lib/agents/markdown/backends/mime-utils.js"
 import { checkAuthorization } from "@cap-js/mcp/lib/auth.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 const unwrap = (result) => {
   const text = result.content?.[0]?.text ?? ""

--- a/srv/push-notification-srv.js
+++ b/srv/push-notification-srv.js
@@ -1,6 +1,6 @@
 import cds from "@sap/cds"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * CDS service that handles push notification delivery.

--- a/tests/integration/telemetry.test.js
+++ b/tests/integration/telemetry.test.js
@@ -241,8 +241,8 @@ describe.skipIf(isHybrid)("@cap-js/agents - GenAI Semantic Conventions", () => {
   before(() => {
     originalQuota = cds.env.agents.pool.maxTasksPerHourPerUser
     cds.env.agents.pool.maxTasksPerHourPerUser = 200
-    // Intercept cds.log("agent").warn after cds is fully bootstrapped
-    const LOG = cds.log("agent")
+    // Intercept cds.log("agents").warn after cds is fully bootstrapped
+    const LOG = cds.log("agents")
     _originalLogWarn = LOG.warn.bind(LOG)
     LOG.warn = function (...args) {
       const msg = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")
@@ -253,7 +253,7 @@ describe.skipIf(isHybrid)("@cap-js/agents - GenAI Semantic Conventions", () => {
   after(() => {
     cds.env.agents.pool.maxTasksPerHourPerUser = originalQuota
     mock.stop()
-    const LOG = cds.log("agent")
+    const LOG = cds.log("agents")
     if (_originalLogWarn) LOG.warn = _originalLogWarn
   })
   beforeEach(() => {

--- a/tests/projects/bookshop/srv/circuit-breaker-service.js
+++ b/tests/projects/bookshop/srv/circuit-breaker-service.js
@@ -3,7 +3,7 @@ import { StateGraph, Annotation, messagesStateReducer } from "@langchain/langgra
 import { circuitBreaker, timeout } from "@sap-cloud-sdk/resilience"
 import { ms4 } from "../../../../lib/utils/utils.js"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Circuit breaker integration test service.

--- a/tests/projects/bookshop/srv/streaming-metrics-service.js
+++ b/tests/projects/bookshop/srv/streaming-metrics-service.js
@@ -1,7 +1,7 @@
 import cds from "@sap/cds"
 import { StateGraph, Annotation, messagesStateReducer } from "@langchain/langgraph"
 
-const LOG = cds.log("agent")
+const LOG = cds.log("agents")
 
 /**
  * Streaming metrics/audit integration test service.

--- a/tests/projects/telemetry-debug/package.json
+++ b/tests/projects/telemetry-debug/package.json
@@ -17,7 +17,7 @@
     },
     "log": {
       "levels": {
-        "agent": "debug"
+        "agents": "debug"
       }
     },
     "mcp": {


### PR DESCRIPTION
### Rename log scope from `"agent"` to `"agents"` and guard verbose debug logs

This PR updates the CDS logging scope used throughout the `@cap-js/agents` plugin from `"agent"` to `"agents"` to better align with the package/namespace convention. Additionally, several `LOG.debug(...)` calls that were unconditionally emitting debug output are now guarded with `LOG._trace &&` to reduce noise at non-trace log levels.

#### Changes summary:

- **Log scope rename** (`"agent"` → `"agents"`): Applied consistently across all source files, including core plugin entry point, agent handlers, persistence stores, telemetry modules, middleware, model adapters, utilities, and test fixtures.
- **Debug log guards**: In `lib/protocol/agent-card.js`, `lib/protocol/persistence/checkpoint-saver.js`, and `lib/protocol/persistence/task-store.js`, verbose `LOG.debug(...)` calls (e.g. "Checkpoint loaded/saved", "Task saved/loaded/not found", "Generated agent card from ...") are now wrapped in `LOG._trace && ...` to prevent them from firing unless trace-level logging is active.
- **`package.json`**: Updated the `watch:hybrid` script's `DEBUG=agent` flag to `DEBUG=agents`.
- **`tests/projects/telemetry-debug/package.json`**: Updated the CDS log level configuration key from `"agent"` to `"agents"`.
- **Test files**: Updated log interception in `tests/integration/telemetry.test.js` to use the renamed `"agents"` scope.

#### Category: Chore / Refactor

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: Repository PR Template
- Correlation ID: `826373b0-9711-11f1-9adf-2f0640aab0f1`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
