### PR TITLE
feat: auth popup in dev for fine-grained service restrictions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ import { CdsTaskStore } from "./protocol/persistence/task-store.js"
 import { CdsPushNotificationStore } from "./protocol/persistence/push-notification-store.js"
 import { CdsPushNotificationSender } from "./protocol/push-notification-sender.js"
 import preview from "./preview/preview.js"
+import { previewAuthChallenge } from "./utils/inner-auth.js"
 import { short, audit } from "./utils/utils.js"
 import { partsToText } from "./utils/message-handling.js"
 import * as metrics from "./telemetry/metrics.js"
@@ -199,7 +200,7 @@ export default function A2AProtocolAdapter(srv, options = {}) {
   })
 
   if (!cds.env.profiles?.includes("production")) {
-    router.use("/preview", preview(agentCard.name || srv.name))
+    router.use("/preview", previewAuthChallenge(srv), preview(agentCard.name || srv.name))
   }
 
   router.post("/", express.json({ limit: "5mb" }), async (req, res) => {

--- a/lib/utils/inner-auth.js
+++ b/lib/utils/inner-auth.js
@@ -1,0 +1,33 @@
+import cds from "@sap/cds"
+
+/**
+ * Dev-only preview auth challenge.
+ *
+ * When a CDS service has NO service-level `@requires`/`@restrict` but SOME
+ * entity or action inside is gated, an anonymous user has no access
+ */
+export const previewAuthChallenge = (srv) => (req, res, next) => {
+  // Auth kind — only mocked participates. `dummy` is intentionally excluded
+  // (grants every role to every user — nothing to challenge). Production auth
+  // strategies (`xsuaa`, `jwt`, `ias`, ...) are untouched.
+  const auth = cds.env.requires?.auth
+  const kind = typeof auth === "string" ? auth : auth?.kind
+  if (kind !== "mocked") return next()
+
+  // Service shape — service itself must be open (else the outer 401 gate in
+  // `lib/index.js` already challenges), but something inside must be gated.
+  const def = srv?.definition
+  if (!def || def["@requires"] || def["@restrict"]) return next()
+  const hasInnerAuth =
+    Object.values(srv.entities || {}).some((e) => e["@requires"] || e["@restrict"]) ||
+    Array.from(srv.actions || []).some((a) => a["@requires"] || a["@restrict"])
+  if (!hasInnerAuth) return next()
+
+  // Caller identity — anonymous callers get the challenge.
+  const user = cds.context?.user || req?.user
+  const anonymous = !user || user._is_anonymous || user.id === "anonymous"
+  if (!anonymous) return next()
+
+  res.setHeader("WWW-Authenticate", `Basic realm="cap-agents:${srv.name}"`)
+  res.status(401).end()
+}

--- a/tests/hybrid/prompt-injection-shield.test.js
+++ b/tests/hybrid/prompt-injection-shield.test.js
@@ -120,7 +120,9 @@ describe("@cap-js/agents - Prompt Injection Shield (AI Core)", () => {
       expect(output).not.toMatch(/^COMPROMISED$/i)
       expect(output).not.toMatch(/Always use the provided tools to answer/i)
       // Should tell user about the attack / filtering
-      expect(output).toMatch(/prompt attack|malicious|filter/i)
+      expect(output).toMatch(
+        /prompt attack|malicious|filter|prompt injection attack|extract sensitive information/i,
+      )
     })
 
     it("should respond normally on follow-up after tool injection was blocked", async () => {

--- a/tests/integration/plugin.test.js
+++ b/tests/integration/plugin.test.js
@@ -21,7 +21,7 @@ describe("@cap-js/agents plugin", () => {
   })
 
   it("should serve the preview UI for @agent services", async () => {
-    const res = await GET("/a2a/catalog/preview")
+    const res = await GET("/a2a/catalog/preview", { auth: { username: "alice", password: "" } })
     expect(res.status).toBe(200)
     expect(res.headers["content-type"]).toMatch(/text\/html/)
     expect(res.data.includes("CatalogService")).toBeTruthy()

--- a/tests/integration/preview-auth-challenge.test.js
+++ b/tests/integration/preview-auth-challenge.test.js
@@ -24,9 +24,7 @@ describe("@cap-js/agents - Preview auth challenge (dev-only)", () => {
     // motivated this middleware — silent HITL loop under a partially-gated agent.
     const res = await GET("/a2a/catalog/preview/")
     expect(res.status).toBe(401)
-    expect(res.headers["www-authenticate"] ?? "").toMatch(
-      /Basic realm="cap-agents:CatalogService"/,
-    )
+    expect(res.headers["www-authenticate"] ?? "").toMatch(/Basic realm="cap-agents:CatalogService"/)
   })
 
   it("authenticated GET /preview on a service with inner auth returns the preview HTML (200)", async () => {

--- a/tests/integration/preview-auth-challenge.test.js
+++ b/tests/integration/preview-auth-challenge.test.js
@@ -19,12 +19,11 @@ describe("@cap-js/agents - Preview auth challenge (dev-only)", () => {
   })
 
   it("anonymous GET /preview on service with action-level @requires returns 401 with Basic challenge", async () => {
-    // CatalogService: no service-level @requires, but submitOrder action carries
-    // @requires: ['authenticated-user']. The bookshop-style scenario that
-    // motivated this middleware — silent HITL loop under a partially-gated agent.
-    const res = await GET("/a2a/catalog/preview/")
+    const res = await GET("/a2a/action-requires/preview/")
     expect(res.status).toBe(401)
-    expect(res.headers["www-authenticate"] ?? "").toMatch(/Basic realm="cap-agents:CatalogService"/)
+    expect(res.headers["www-authenticate"] ?? "").toMatch(
+      /Basic realm="cap-agents:ActionRequiresService"/,
+    )
   })
 
   it("authenticated GET /preview on a service with inner auth returns the preview HTML (200)", async () => {

--- a/tests/integration/preview-auth-challenge.test.js
+++ b/tests/integration/preview-auth-challenge.test.js
@@ -1,0 +1,55 @@
+import cds from "@sap/cds"
+
+const { GET, axios } = cds.test(import.meta.dirname + "/../projects/bookshop")
+
+// Non-2xx responses must resolve (not throw) so we can assert on status codes.
+axios.defaults.validateStatus = () => true
+
+const ALICE = { username: "alice", password: "" }
+
+describe("@cap-js/agents - Preview auth challenge (dev-only)", () => {
+  it("anonymous GET /preview on service with entity-level @restrict returns 401 with Basic challenge", async () => {
+    // EntityRestrictService: no service-level @requires, but entity SecretBooks
+    // is @restrict-ed. Anonymous callers must be prompted to authenticate.
+    const res = await GET("/a2a/entity-restrict/preview/")
+    expect(res.status).toBe(401)
+    expect(res.headers["www-authenticate"] ?? "").toMatch(
+      /Basic realm="cap-agents:EntityRestrictService"/,
+    )
+  })
+
+  it("anonymous GET /preview on service with action-level @requires returns 401 with Basic challenge", async () => {
+    // CatalogService: no service-level @requires, but submitOrder action carries
+    // @requires: ['authenticated-user']. The bookshop-style scenario that
+    // motivated this middleware — silent HITL loop under a partially-gated agent.
+    const res = await GET("/a2a/catalog/preview/")
+    expect(res.status).toBe(401)
+    expect(res.headers["www-authenticate"] ?? "").toMatch(
+      /Basic realm="cap-agents:CatalogService"/,
+    )
+  })
+
+  it("authenticated GET /preview on a service with inner auth returns the preview HTML (200)", async () => {
+    const res = await GET("/a2a/entity-restrict/preview/", { auth: ALICE })
+    expect(res.status).toBe(200)
+    expect(res.headers["content-type"] ?? "").toMatch(/text\/html/)
+    // Chat preview renders the agent name into the template.
+    expect(res.data).toMatch(/EntityRestrictService/)
+  })
+
+  it("anonymous GET /preview on a fully-open service returns 200 (no inner auth to protect)", async () => {
+    // GraphBookService: no @requires/@restrict anywhere. Anonymous is fine, no challenge.
+    const res = await GET("/a2a/graph-book/preview/")
+    expect(res.status).toBe(200)
+    expect(res.headers["content-type"] ?? "").toMatch(/text\/html/)
+  })
+
+  it("service-level @requires still owns the challenge (no double-hit, existing gate wins)", async () => {
+    // RestrictedAgentService has @requires: 'admin' on the service. The outer
+    // gate at lib/index.js:52-118 emits 401 with realm="Users" already. Our
+    // preview middleware must not interfere or override that.
+    const res = await GET("/a2a/restricted-agent/preview")
+    expect(res.status).toBe(401)
+    expect(res.headers["www-authenticate"] ?? "").toMatch(/Basic realm="Users"/)
+  })
+})

--- a/tests/projects/bookshop/srv/action-requires-service.cds
+++ b/tests/projects/bookshop/srv/action-requires-service.cds
@@ -1,0 +1,14 @@
+using {sap.capire.bookshop as my} from '../db/schema';
+
+/**
+ * Service with no service-level @requires but ONE action that is @requires-gated.
+ * Mirrors the real upstream `capire/bookshop` shape (open service + gated action)
+ * and drives the preview auth-challenge test for the action-level branch.
+ */
+@agent
+service ActionRequiresService {
+  @readonly entity Books as projection on my.Books { ID, title };
+
+  @requires: 'authenticated-user'
+  action    submitOrder(book: Books:ID, quantity: Integer) returns { stock: Integer };
+}

--- a/tests/projects/bookshop/srv/cat-service.cds
+++ b/tests/projects/bookshop/srv/cat-service.cds
@@ -39,6 +39,7 @@ service CatalogService {
    */
   @description: 'Submit an order for a book'
   @agent.hitl
+  @requires   : ['authenticated-user']
   action   submitOrder(book: Books:ID @mandatory,
                        quantity: Integer @mandatory
   )                                                                              returns {

--- a/tests/projects/bookshop/srv/cat-service.cds
+++ b/tests/projects/bookshop/srv/cat-service.cds
@@ -39,7 +39,6 @@ service CatalogService {
    */
   @description: 'Submit an order for a book'
   @agent.hitl
-  @requires   : ['authenticated-user']
   action   submitOrder(book: Books:ID @mandatory,
                        quantity: Integer @mandatory
   )                                                                              returns {


### PR DESCRIPTION
## feat: Auth popup in dev for fine-grained service restrictions

### Description

Adds a dev-only middleware (`previewAuthChallenge`) that issues an HTTP `401 Basic` challenge on the `/preview` route when an anonymous user tries to access a service that has **no service-level** `@requires`/`@restrict` annotation but **does** contain entity- or action-level restrictions.

Previously, anonymous users would silently reach the preview UI without being prompted to authenticate, potentially causing confusing HITL (Human-in-the-Loop) loops when inner-gated actions were invoked. This change surfaces the authentication prompt early and only when necessary.

### Changes

**`lib/utils/inner-auth.js`** _(new file)_
- Introduces `previewAuthChallenge(srv)` middleware.
- Only activates for `mocked` auth strategy (explicitly excludes `dummy` and production strategies like `xsuaa`, `jwt`, `ias`).
- Checks if the service itself is open but has inner-gated entities or actions.
- Issues `WWW-Authenticate: Basic realm="cap-agents:<ServiceName>"` + `401` for anonymous callers; otherwise delegates to `next()`.

**`lib/index.js`** _(modified)_
- Injects `previewAuthChallenge(srv)` as middleware before the preview route handler in non-production profiles.

**`tests/integration/preview-auth-challenge.test.js`** _(new file)_
- Integration tests covering:
  - Entity-level `@restrict` triggers `401` with correct `Basic` realm for anonymous users.
  - Action-level `@requires` triggers `401` with correct `Basic` realm for anonymous users.
  - Authenticated users receive `200` HTML preview.
  - Fully open services (no inner auth) return `200` without challenge.
  - Service-level `@requires` continues to own the challenge via the existing gate (no double-hit).

### Category

🆕 **New Feature**

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- File Content Strategy: Full file content
- Correlation ID: `ec01d740-971f-11f1-80e3-e78721a4ee17`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
