### PR TITLE
chore: add REUSE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/agents)](https://api.reuse.software/info/github.com/cap-js/agents)
+
 # SAP Cloud Application Programming Model, agent development plugin for Node.js
 
 ## About this project


### PR DESCRIPTION
Added missing REUSE badge, this is typically added by our bot when the repository is created, but for some reason, this time it was not (or that change was reverted somehow).

If you see it still in status "Checking", that's normal, it is because it was just recently registered.

### Have you...

- N/A Added relevant entry to the change log?
