### PR TITLE
chore: status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/agents)](https://api.reuse.software/info/github.com/cap-js/agents)
-
 # SAP Cloud Application Programming Model, agent development plugin for Node.js
 
 ## About this project


### PR DESCRIPTION
The REUSE status badge is in status checking since 6 days. Removing it from the readme until the check is working.

Current status:
[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/agents)](https://api.reuse.software/info/github.com/cap-js/agents)