### PR TITLE
feat: allow spec of resource group via env var

### DIFF
--- a/.docs/connectivity.md
+++ b/.docs/connectivity.md
@@ -7,7 +7,7 @@
 
 Beyond binding a service instance with `cds bind -2 <instance>`, the plugin can reach SAP AI Core in the following ways:
 
-- **`AICORE_SERVICE_KEY` environment variable** — set it to the JSON service key of your AI Core instance. Useful for local development without a binding.
+- **`AICORE_SERVICE_KEY` environment variable** — set it to the JSON service key of your AI Core instance. Useful for local development without a binding. Additionally you can set a specific resource group with `AICORE_RESOURCE_GROUP` if it's not the "default" one.
 - **BTP Destination** — for a central AI Core instance shared across subaccounts (see [Destination-Based Connectivity](#destination-based-connectivity) below).
 
 When neither a destination nor `AICORE_SERVICE_KEY` is set, the plugin falls back to the standard service binding resolution (`VCAP_SERVICES`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version ...
+
+### Added
+
+- Allow specification of AI Core resource group via AICORE_RESOURCE_GROUP env var
+
 ## Version 0.9.1 - 2026-08-14
 
 ### Added

--- a/lib/models/aicore.js
+++ b/lib/models/aicore.js
@@ -9,7 +9,7 @@ const LOG = cds.log("agents")
 
 class _InstrumentedOrchestrationClient extends OrchestrationClient {
   constructor(name, options) {
-    const { model, deepAgent, streaming, destinationName, resourceGroup } = options
+    const { model, deepAgent, streaming, destinationName, resourceGroup = process.env.AICORE_RESOURCE_GROUP } = options
     const flatten = options.flatten ?? (deepAgent ? true : false)
 
     // Restore pre-72ef6fa params resolution: caller > deep-agent default > root


### PR DESCRIPTION
For [local dev without a binding](https://github.com/cap-js/agents/blob/HEAD/.docs/connectivity.md#connecting-to-sap-ai-core), AICORE_SERVICE_KEY is useful to supply binding info. But sometimes a non-default resource group is required. This adds the ability to specify one via AICORE_RESOURCE_GROUP.

### Have you...

- [x] Added relevant entry to the change log?
