### PR TITLE
chore: add link for ReAct agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Both approaches start from a CDS service annotated with `@agent` (as shown in [R
 
 ### Agentify Existing CAP Services
 
-With `@agent` alone, the plugin auto-generates tools from the service's entities and actions, creates a ReAct agent loop, and serves it as a remote agent — no code required.
+With `@agent` alone, the plugin auto-generates tools from the service's entities and actions, creates a [ReAct agent](https://arxiv.org/abs/2210.03629) loop, and serves it as a remote agent — no code required.
 
 ```cds
 @agent


### PR DESCRIPTION
### Add Hyperlink for ReAct Agent Reference in README

**Category:** Documentation 📝

This PR adds a hyperlink to the academic paper for the ReAct agent concept in the README.

The term "ReAct agent" in the README now links to the original paper at `https://arxiv.org/abs/2210.03629`, providing readers with a direct reference to learn more about the underlying methodology.

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.45`

- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Correlation ID: `92f5e450-a12b-11f1-984e-dbce6b7676cc`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: Repository PR Template
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
