### PR TITLE
chore: 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 0.9.2 - TBD
+## Version 0.9.2 - 2026-08-26
 
 ### Added
 

--- a/lib/protocol/persistence/cleanup.js
+++ b/lib/protocol/persistence/cleanup.js
@@ -50,7 +50,8 @@ export async function triggerCleanup(serviceName) {
     return
   }
   serviceMap.set(serviceName, Date.now())
-  const delay = ttlMs + MS_OF_A_DAY
+  const MAX_TIMEOUT = 2_147_483_647
+  const delay = Math.min(ttlMs + MS_OF_A_DAY, MAX_TIMEOUT)
   await srv.schedule("cleanupTasks", {}).after(delay)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/agents",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/agents",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "workspaces": [
         "tests/projects/bookshop/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/agents",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "CDS plugin for building agents",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",


### PR DESCRIPTION
## chore: Release v0.9.2

This PR bumps the package version from `0.9.1` to `0.9.2` and finalizes the changelog release date.

### Changes

- **Version bump**: Updated `package.json` and `package-lock.json` to `0.9.2`
- **Changelog**: Set release date for `0.9.2` from `TBD` to `2026-08-26`
- **Bug fix** in `lib/protocol/persistence/cleanup.js`: Capped the scheduled cleanup delay to the maximum safe timeout value (`2,147,483,647` ms) to prevent overflow issues with large TTL values:
  ```js
  const MAX_TIMEOUT = 2_147_483_647
  const delay = Math.min(ttlMs + MS_OF_A_DAY, MAX_TIMEOUT)
  ```

### Category

🐛 **Bug Fix** / 🏷️ **Chore** (release)

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: Repository PR Template
- Correlation ID: `461c1160-a156-11f1-93f2-0b2a0dc04dd5`
</details>
