### PR TITLE
chore: add @cap-js/node-js-runtime to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cap-js/agents-team
+* @cap-js/node-js-runtime


### PR DESCRIPTION
### Add `@cap-js/node-js-runtime` to CODEOWNERS

**Category:** Chore

Adds `@cap-js/node-js-runtime` as a code owner in the `.github/CODEOWNERS` file, ensuring the team is automatically requested for reviews on relevant pull requests.

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.47`

- Event Trigger: `pull_request.ready_for_review`
- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `7028af90-a156-11f1-9632-6ebd8038c079`
</details>
