### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @cap-js/agents-team
-* @cap-js/node-js-runtime
+* @cap-js/agents-team @cap-js/node-js-runtime


### PR DESCRIPTION
### Fix CODEOWNERS Configuration

Update the `.github/CODEOWNERS` file to correctly assign multiple code owners on a single line.

**Change:** Combined the two separate wildcard (`*`) entries for `@cap-js/agents-team` and `@cap-js/node-js-runtime` into a single rule, ensuring both teams are required reviewers for all files.

> Previously, having two separate `*` rules meant only the last rule (`@cap-js/node-js-runtime`) would take effect, as later rules override earlier ones in CODEOWNERS.

**Category:** 🔧 Chore

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.52`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `bd9701a0-a1ec-11f1-9966-cea009059ae3`
- Output Template: Repository PR Template
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
