### PR TITLE
fix: use @sap-cloud-sdk/resilience/internal to access circuitBreakers map

### DIFF
--- a/tests/integration/resilience.test.js
+++ b/tests/integration/resilience.test.js
@@ -15,9 +15,15 @@ const { sendMessage } = createHelpers({ POST, axios })
 const require = createRequire(import.meta.url)
 let circuitBreakers
 try {
-  circuitBreakers = require("@sap-cloud-sdk/resilience/dist/circuit-breaker.js").circuitBreakers
+  // 4.9.1+: package.json exports field exposes ./internal; dist/circuit-breaker.js is blocked
+  circuitBreakers = require("@sap-cloud-sdk/resilience/internal").circuitBreakers
 } catch {
-  circuitBreakers = null
+  try {
+    // <4.9.0: no exports field, deep path works
+    circuitBreakers = require("@sap-cloud-sdk/resilience/dist/circuit-breaker.js").circuitBreakers
+  } catch {
+    circuitBreakers = null
+  }
 }
 
 describe("@cap-js/agents - LLM Circuit Breaker", () => {


### PR DESCRIPTION
## Root cause

The dependabot PR #69 bumps `@sap-cloud-sdk/resilience` from `4.8.0` → `4.9.1`. In `4.9.1`, the package added an `exports` field to `package.json`. That field only allows access to `.` (main), `./internal`, `./internal.js`, and `./package.json`.

The resilience test was accessing the `circuitBreakers` map via a **deep import** that is no longer permitted:
```js
require("@sap-cloud-sdk/resilience/dist/circuit-breaker.js").circuitBreakers
```
With the `exports` constraint in place, Node.js throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, the `try` block catches it, and `circuitBreakers` is set to `null`. The `beforeEach` hook that clears the map then becomes a no-op, leaking circuit breaker state between tests — causing:
- `should open circuit breaker after repeated 5xx failures` → breaker already open from a prior test, `mock.getCallCount()` is 1 not 0
- `should recover after circuit breaker state is reset` → can't clear state, breaker still open, result is `failed` not `completed`

## Fix

- Primary: import via `@sap-cloud-sdk/resilience/internal` (the new exported subpath that re-exports everything from `circuit-breaker.ts` including `circuitBreakers`)
- Fallback: retain the old deep-path as a secondary try/catch for versions < 4.9.1 that have no `exports` field

## Test plan
- [ ] CI passes on PR #69 after this is merged to main
- [ ] Resilience test passes with both `@sap-cloud-sdk/resilience@4.8.0` and `4.9.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)