### PR TITLE
chore: Include payload in error if content filter is unavailable

### DIFF
--- a/lib/agents/middleware/content-filter.js
+++ b/lib/agents/middleware/content-filter.js
@@ -136,9 +136,10 @@ export async function contentFilterMiddleware(model) {
             }
           } else {
             // Fail closed: unrecognized errors (timeout, 5xx, network) block the message
-            LOG.warn("Content filter unavailable — blocking input", {
+            LOG.error("Content filter unavailable — blocking input", {
               error: err.message,
               status,
+              data,
             })
             if (hasHumanMessage) {
               return {


### PR DESCRIPTION
Makes debugging easier by marking it as an error and including the payload

### Have you...

- [x] Added relevant entry to the change log?
