### PR TITLE
chore: status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/agents)](https://api.reuse.software/info/github.com/cap-js/agents)
+
 # SAP Cloud Application Programming Model, agent development plugin for Node.js
 
 ## About this project


### PR DESCRIPTION
Status badge was removed in #46 due to temporary issues in the reuse validation. The validation is meanwhile completed and the badge is green -> add it again