### PR TITLE
fix: a2a responses contained duplicate texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 0.9.4 - tbd
+
+### Fixed
+
+- Remote A2A response does not yield duplicate content
+
 ## Version 0.9.3 - 2026-09-04
 
 ### Added

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -660,7 +660,7 @@
         } else {
           // Append to current open step for this artifactId
           const idx = thinkingStepEls.length - 1
-          thinkingTexts[idx] += text
+          thinkingTexts[idx] += '\n' + text
           thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
         }
         if (lastChunk) currentThinkingClosed = true

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -649,12 +649,10 @@
         if (append && idx >= 0) {
           thinkingTexts[idx] += text
           thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
-        }
-        else if (artifactId === currentThinkingArtifactId && !currentThinkingClosed) {
-          thinkingTexts[idx] += '\n' + text
+        } else if (artifactId === currentThinkingArtifactId && !currentThinkingClosed) {
+          thinkingTexts[idx] += "\n" + text
           thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
-        }
-        else {
+        } else {
           const step = document.createElement("div")
           step.className = "thinking-step"
           step._artifactId = artifactId
@@ -1104,7 +1102,8 @@
 
           if (event.artifact?.artifactId?.startsWith("thinking")) {
             const lastChunk = event.lastChunk ?? false
-            if (text) addThinkingStep(event.artifact.artifactId, text, lastChunk, event.append ?? false)
+            if (text)
+              addThinkingStep(event.artifact.artifactId, text, lastChunk, event.append ?? false)
             return null
           }
 

--- a/lib/preview/chat.html
+++ b/lib/preview/chat.html
@@ -616,7 +616,7 @@
       function flushPendingThinkingUpdate() {
         const pending = pendingThinkingUpdate
         clearPendingThinkingUpdate()
-        if (pending) renderThinkingStep(pending.artifactId, pending.text, pending.lastChunk)
+        if (pending) renderThinkingStep(pending)
       }
 
       function prefersReducedMotion() {
@@ -642,10 +642,19 @@
         else expandThinkingSummary(el)
       }
 
-      function renderThinkingStep(artifactId, text, lastChunk) {
+      function renderThinkingStep(update) {
+        const { artifactId, text, lastChunk, append } = update
         const panel = ensureThinkingSummary()
-        const isNewStep = artifactId !== currentThinkingArtifactId || currentThinkingClosed
-        if (isNewStep) {
+        const idx = thinkingStepEls.findIndex((step) => step._artifactId === artifactId)
+        if (append && idx >= 0) {
+          thinkingTexts[idx] += text
+          thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
+        }
+        else if (artifactId === currentThinkingArtifactId && !currentThinkingClosed) {
+          thinkingTexts[idx] += '\n' + text
+          thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
+        }
+        else {
           const step = document.createElement("div")
           step.className = "thinking-step"
           step._artifactId = artifactId
@@ -657,17 +666,12 @@
           updateThinkingSummaryLabel()
           currentThinkingArtifactId = artifactId
           currentThinkingClosed = false
-        } else {
-          // Append to current open step for this artifactId
-          const idx = thinkingStepEls.length - 1
-          thinkingTexts[idx] += '\n' + text
-          thinkingStepEls[idx].innerHTML = md(thinkingTexts[idx])
         }
         if (lastChunk) currentThinkingClosed = true
         messages.scrollTop = messages.scrollHeight
       }
 
-      function addThinkingStep(artifactId, text, lastChunk) {
+      function addThinkingStep(artifactId, text, lastChunk, append) {
         if (
           pendingThinkingUpdate &&
           pendingThinkingUpdate.artifactId === artifactId &&
@@ -677,7 +681,7 @@
           pendingThinkingUpdate.lastChunk = lastChunk
         } else {
           flushPendingThinkingUpdate()
-          pendingThinkingUpdate = { artifactId, text, lastChunk }
+          pendingThinkingUpdate = { artifactId, text, lastChunk, append }
         }
 
         if (pendingThinkingTimer) clearTimeout(pendingThinkingTimer)
@@ -1100,7 +1104,7 @@
 
           if (event.artifact?.artifactId?.startsWith("thinking")) {
             const lastChunk = event.lastChunk ?? false
-            if (text) addThinkingStep(event.artifact.artifactId, text, lastChunk)
+            if (text) addThinkingStep(event.artifact.artifactId, text, lastChunk, event.append ?? false)
             return null
           }
 

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -4,8 +4,9 @@ import { z } from "zod"
 import { LangGraphExecutor } from "../langgraph-executor-srv.js"
 import { short, toolName } from "../../lib/utils/utils.js"
 
-const LOG = cds.log("agents:sub-agents")
+const LOG = cds.log("agents:sub-agents|agents|sub-agents")
 
+import { inspect } from "util"
 /**
  * Extract text and file parts from an A2A response (task or message).
  */
@@ -23,8 +24,8 @@ function extractResult(result) {
   }
 
   if (result.kind === "task") {
-    processParts(result.status?.message?.parts)
-    for (const artifact of result.artifacts || []) processParts(artifact.parts)
+    if (result.status?.message) processParts(result.status.message.parts)
+    else if (result.artifacts) for (let artifact of result.artifacts) processParts(artifact.parts)
     if (text.length === 0 && files.length === 0) {
       return { text: `Task ${result.id}: ${result.status?.state || "unknown"}`, files: [] }
     }
@@ -71,21 +72,27 @@ function formatToolResult({ text, files }) {
  * Wrap an A2A client as a LangChain tool the agent can call.
  */
 function createA2ATool(client, agentCard) {
+  const subagent = agentCard.name
   return tool(
     async ({ message }) => {
       try {
+        const messageId = cds.utils.uuid()
+        LOG.info(`Sending message to ${subagent}`, { messageId }, '\n\n'+ message +'\n')
         const result = await client.sendMessage({
           message: {
             kind: "message",
             role: "user",
-            messageId: cds.utils.uuid(),
+            messageId,
             parts: [{ kind: "text", text: message }],
           },
         })
-        return formatToolResult(extractResult(result))
+        if (LOG._debug) LOG.trace (`Raw results from ${subagent}`, inspect (result, { depth: null, colors: true }))
+        let response = formatToolResult(extractResult(result))
+        if (response) LOG.info (`Got response from ${subagent}`, { messageId }, '\n\n'+ response +'\n')
+        return response
       } catch (err) {
-        LOG.warn("Sub-agent tool error", { agent: agentCard.name, error: err.message })
-        return `Error communicating with ${agentCard.name}: ${err.message}`
+        LOG.warn("Sub agent tool error", { subagent, error: err.message })
+        return `Error communicating with ${subagent}: ${err.message}`
       }
     },
     {

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -24,8 +24,10 @@ function extractResult(result) {
   }
 
   if (result.kind === "task") {
-    if (result.status?.message) processParts(result.status.message.parts)
-    else if (result.artifacts) for (let artifact of result.artifacts) processParts(artifact.parts)
+    if (result.artifacts) for (let artifact of result.artifacts) {
+      if (!artifact.artifactId.startsWith('thinking')) processParts(artifact.parts)
+    }
+    else if (result.status?.message) processParts(result.status.message.parts)
     if (text.length === 0 && files.length === 0) {
       return { text: `Task ${result.id}: ${result.status?.state || "unknown"}`, files: [] }
     }

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -15,7 +15,7 @@ function extractResult(result) {
   const text = []
   const files = []
 
-  const processParts = (parts = []) => {
+  const processParts = (parts) => {
     for (const part of parts) {
       if (part.kind === "text") text.push(part.text)
       else if (part.kind === "file") files.push(part)

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -106,7 +106,7 @@ export async function buildSubAgentToolLocally(serviceName) {
 
   const { generateAgentCard } = await import("../../lib/protocol/agent-card.js")
   const agentCard = generateAgentCard(srv)
-  LOG.info(`Wired local sub-agent "${agentCard.name}" (${serviceName})`)
+  LOG.info(`Connecting to sub agent ${serviceName}`, '(local)')
 
   const { RequestContext, DefaultExecutionEventBus } = await import("@a2a-js/sdk/server")
 
@@ -280,7 +280,7 @@ export async function buildSubAgentToolFromConnection(serviceName) {
 
   const path = typeof credentials === "object" ? credentials?.path : null
   const base = agentBaseUrl.replace(/\/$/, "") + (path ? `/${path.replace(/^\//, "")}` : "")
-  LOG.info(`Connecting to sub-agent at ${base}`)
+  LOG.info(`Connecting to sub agent ${serviceName}`, { at: base })
 
   // revisit: a2a agents may be tenant specific, card per tenant?
   const initialHeaders = await resolveHeaders()
@@ -294,7 +294,6 @@ export async function buildSubAgentToolFromConnection(serviceName) {
     )
   }
   const agentCard = await cardRes.json()
-  LOG.info(`Connected to sub-agent "${agentCard.name}" (${serviceName})`)
 
   const { ClientFactory, ClientFactoryOptions, JsonRpcTransportFactory, RestTransportFactory } =
     await import("@a2a-js/sdk/client")

--- a/srv/handlers/sub-agent-tools.js
+++ b/srv/handlers/sub-agent-tools.js
@@ -24,9 +24,10 @@ function extractResult(result) {
   }
 
   if (result.kind === "task") {
-    if (result.artifacts) for (let artifact of result.artifacts) {
-      if (!artifact.artifactId.startsWith('thinking')) processParts(artifact.parts)
-    }
+    if (result.artifacts)
+      for (let artifact of result.artifacts) {
+        if (!artifact.artifactId.startsWith("thinking")) processParts(artifact.parts)
+      }
     else if (result.status?.message) processParts(result.status.message.parts)
     if (text.length === 0 && files.length === 0) {
       return { text: `Task ${result.id}: ${result.status?.state || "unknown"}`, files: [] }
@@ -79,7 +80,7 @@ function createA2ATool(client, agentCard) {
     async ({ message }) => {
       try {
         const messageId = cds.utils.uuid()
-        LOG.info(`Sending message to ${subagent}`, { messageId }, '\n\n'+ message +'\n')
+        LOG.info(`Sending message to ${subagent}`, { messageId }, "\n\n" + message + "\n")
         const result = await client.sendMessage({
           message: {
             kind: "message",
@@ -88,9 +89,11 @@ function createA2ATool(client, agentCard) {
             parts: [{ kind: "text", text: message }],
           },
         })
-        if (LOG._debug) LOG.trace (`Raw results from ${subagent}`, inspect (result, { depth: null, colors: true }))
+        if (LOG._debug)
+          LOG.trace(`Raw results from ${subagent}`, inspect(result, { depth: null, colors: true }))
         let response = formatToolResult(extractResult(result))
-        if (response) LOG.info (`Got response from ${subagent}`, { messageId }, '\n\n'+ response +'\n')
+        if (response)
+          LOG.info(`Got response from ${subagent}`, { messageId }, "\n\n" + response + "\n")
         return response
       } catch (err) {
         LOG.warn("Sub agent tool error", { subagent, error: err.message })
@@ -115,7 +118,7 @@ export async function buildSubAgentToolLocally(serviceName) {
 
   const { generateAgentCard } = await import("../../lib/protocol/agent-card.js")
   const agentCard = generateAgentCard(srv)
-  LOG.info(`Connecting to sub agent ${serviceName}`, '(local)')
+  LOG.info(`Connecting to sub agent ${serviceName}`, "(local)")
 
   const { RequestContext, DefaultExecutionEventBus } = await import("@a2a-js/sdk/server")
 


### PR DESCRIPTION
Besides minor changes to improve log and debug output, this PR fixes an apparent erroneous handling of a2a responses from sub agents in https://github.com/cap-js/agents/pull/86/commits/15fbd93779241a218228bf8be70912c7aaf5aac6:

Before, a single response, say from EventsService, was concatenated into the `text` string in the return, which was collected from `result.status.message.parts` as well as from `result.artifacts.parts`. Debugging revealed that by that the ultimate returned texts contained the actual text **three times**. → Why did that work at all? When did the deduplication happen? Likely that caused lots of quota exceed errors seen in demos. 

### PLEASE DOUBLE CHECK: 

1. Is the fix with the `else` correct?
2. Is it correct to do that on client side, or should it be fixed on subagent server side?