### PR TITLE
feat: Adding cds.folders.srvs: srv/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Remote A2A response does not yield duplicate content
+- Added `cds.folders.srvs` to support adjacent agent markdowns ootb.
 
 ## Version 0.9.3 - 2026-09-04
 

--- a/package.json
+++ b/package.json
@@ -217,6 +217,9 @@
           "_javaHcqlCompat": true
         }
       }
+    },
+    "folders": {
+      "srvs": "srv/*"
     }
   },
   "workspaces": [


### PR DESCRIPTION
With that we can place service definitions into subfolders of `./srv` with markdowns like `AGENT.md` and `*/SKILL.md` next to it. 