### PR TITLE
feat: added a tool filter for remote MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Two new metrics about HITL reporting for which tools HITL was enforced and how the user decided
+- Remote MCP connections support `mcp.tools` in `cds.requires` to restrict which tools are exposed to the agent
 
 ### Changed
 

--- a/lib/agents/middleware/remote-mcp.js
+++ b/lib/agents/middleware/remote-mcp.js
@@ -19,13 +19,14 @@ export function remoteMcpMiddleware() {
       const cache = (cds.context.__mcpDynamicTools ??= {})
       const placeholders = (request.tools ?? []).filter((t) => t._mcpDynamic)
       await Promise.all(
-        placeholders.map(async ({ mcpUrl, serviceName, resolveHeaders }) => {
+        placeholders.map(async ({ mcpUrl, serviceName, resolveHeaders, toolFilter }) => {
           if (cache[mcpUrl]) return
           const headers = await resolveHeaders()
           const client = new MultiServerMCPClient({
             mcpServers: { default: { transport: "http", url: mcpUrl, headers } },
           })
-          const raw = await client.getTools()
+          let raw = await client.getTools()
+          if (toolFilter?.length) raw = raw.filter((t) => toolFilter.includes(t.name))
           for (const t of raw) t.name = toolName(`${serviceName}_${t.name}`)
           cache[mcpUrl] = raw
           LOG.debug(

--- a/srv/handlers/mcp-tools.js
+++ b/srv/handlers/mcp-tools.js
@@ -113,7 +113,8 @@ export async function buildMcpToolsFromConnection(serviceName) {
     return token ? { Authorization: `Bearer ${token}` } : {}
   }
 
-  return { _mcpDynamic: true, mcpUrl, serviceName, resolveHeaders }
+  const toolFilter = cds.requires[serviceName]?.mcp?.tools
+  return { _mcpDynamic: true, mcpUrl, serviceName, resolveHeaders, toolFilter }
 }
 
 export async function buildMcpTools(serviceName) {

--- a/tests/integration/remote-mcp-filter.test.js
+++ b/tests/integration/remote-mcp-filter.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit-style tests for the mcp.tools filter in remoteMcpMiddleware.
+ *
+ * Mocks MultiServerMCPClient so no real MCP server is needed.
+ */
+import cds from "@sap/cds"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+
+// ── Mock MultiServerMCPClient before importing the middleware ─────────────────
+
+const mockGetTools = vi.fn()
+vi.mock("@langchain/mcp-adapters", () => ({
+  MultiServerMCPClient: vi.fn().mockImplementation(function () {
+    this.getTools = mockGetTools
+  }),
+}))
+
+const { remoteMcpMiddleware } = await import("../../lib/agents/middleware/remote-mcp.js")
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMcpConfig(toolFilter) {
+  return {
+    _mcpDynamic: true,
+    mcpUrl: "http://mock-mcp/mcp",
+    serviceName: "testservice",
+    resolveHeaders: async () => ({}),
+    toolFilter,
+  }
+}
+
+function makeFakeTools(...names) {
+  return names.map((name) => ({ name, invoke: vi.fn(), schema: { type: "object" } }))
+}
+
+async function resolveTools(toolFilter) {
+  const mcpConfig = makeMcpConfig(toolFilter)
+  // Set up cds.context and invoke wrapModelCall
+  cds.context = { __mcpDynamicTools: {} }
+  mockGetTools.mockResolvedValueOnce(makeFakeTools("query", "describe", "insert"))
+
+  let capturedTools
+  const middleware = remoteMcpMiddleware()
+  await middleware.wrapModelCall(
+    { tools: [mcpConfig] }, // MCP placeholder — resolved and filtered by the middleware
+    (req) => {
+      capturedTools = req.tools
+      return {}
+    },
+  )
+  return capturedTools
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("remoteMcpMiddleware — mcp.tools filter", () => {
+  beforeEach(() => {
+    mockGetTools.mockReset()
+    cds.context = {}
+  })
+
+  it("returns all tools when no toolFilter is set", async () => {
+    const tools = await resolveTools(undefined)
+    const names = tools.map((t) => t.name)
+    expect(names).toContain("testservice_query")
+    expect(names).toContain("testservice_describe")
+    expect(names).toContain("testservice_insert")
+  })
+
+  it("returns all tools when toolFilter is an empty array", async () => {
+    const tools = await resolveTools([])
+    expect(tools.length).toBe(3)
+  })
+
+  it("filters to only the specified tools (exact match)", async () => {
+    const tools = await resolveTools(["query", "describe"])
+    const names = tools.map((t) => t.name)
+    expect(names).toEqual(["testservice_query", "testservice_describe"])
+    expect(names).not.toContain("testservice_insert")
+  })
+
+  it("returns empty array when none of the specified tools exist", async () => {
+    const tools = await resolveTools(["nonexistent"])
+    expect(tools).toHaveLength(0)
+  })
+
+  it("filter matches raw MCP tool names, not the prefixed names", async () => {
+    // "query" is the raw name; "testservice_query" is the prefixed name exposed to the agent.
+    // The filter must be specified using raw names (as declared in the MCP server).
+    const withRawName = await resolveTools(["query"])
+    expect(withRawName.map((t) => t.name)).toContain("testservice_query")
+
+    const withPrefixedName = await resolveTools(["testservice_query"])
+    expect(withPrefixedName).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Usecase

When an agent connects to a remote MCP server, it may only need a subset of the tools that server exposes. Passing unnecessary tools to the LLM increases token usage and can confuse the model with irrelevant options.

This PR adds a mcp.tools filter to cds.requires, letting developers declaratively restrict which tools are made available:

```cds
"cds": {
  "requires": {
    "github-mcp": {
      "kind": "mcp",
      "mcp": { "tools": ["query", "describe"] }
    }
  }
}
```

Without this: developers had to override buildTools and manually filter out unwanted tools in application code.

With this: a one-line config change is enough, and no application code is needed.

### Have you...

- [ x ] Added relevant entry to the change log?
