### PR TITLE
feat: tool filter for remote MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Two new metrics about HITL reporting for which tools HITL was enforced and how the user decided
+- Remote MCP connections support `mcp.tools` in `cds.requires` to restrict which tools are exposed to the agent
 
 ### Changed
 

--- a/lib/agents/middleware/remote-mcp.js
+++ b/lib/agents/middleware/remote-mcp.js
@@ -19,13 +19,14 @@ export function remoteMcpMiddleware() {
       const cache = (cds.context.__mcpDynamicTools ??= {})
       const placeholders = (request.tools ?? []).filter((t) => t._mcpDynamic)
       await Promise.all(
-        placeholders.map(async ({ mcpUrl, serviceName, resolveHeaders }) => {
+        placeholders.map(async ({ mcpUrl, serviceName, resolveHeaders, toolFilter }) => {
           if (cache[mcpUrl]) return
           const headers = await resolveHeaders()
           const client = new MultiServerMCPClient({
             mcpServers: { default: { transport: "http", url: mcpUrl, headers } },
           })
-          const raw = await client.getTools()
+          let raw = await client.getTools()
+          if (toolFilter?.length) raw = raw.filter((t) => toolFilter.includes(t.name))
           for (const t of raw) t.name = toolName(`${serviceName}_${t.name}`)
           cache[mcpUrl] = raw
           LOG.debug(

--- a/srv/handlers/mcp-tools.js
+++ b/srv/handlers/mcp-tools.js
@@ -113,7 +113,8 @@ export async function buildMcpToolsFromConnection(serviceName) {
     return token ? { Authorization: `Bearer ${token}` } : {}
   }
 
-  return { _mcpDynamic: true, mcpUrl, serviceName, resolveHeaders }
+  const toolFilter = cds.requires[serviceName]?.mcp?.tools
+  return { _mcpDynamic: true, mcpUrl, serviceName, resolveHeaders, toolFilter }
 }
 
 export async function buildMcpTools(serviceName) {

--- a/tests/integration/remote-mcp-filter.test.js
+++ b/tests/integration/remote-mcp-filter.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit-style tests for the mcp.tools filter in remoteMcpMiddleware.
+ *
+ * Mocks MultiServerMCPClient so no real MCP server is needed.
+ */
+import cds from "@sap/cds"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+
+// ── Mock MultiServerMCPClient before importing the middleware ─────────────────
+
+const mockGetTools = vi.fn()
+vi.mock("@langchain/mcp-adapters", () => ({
+  MultiServerMCPClient: vi.fn().mockImplementation(function () {
+    this.getTools = mockGetTools
+  }),
+}))
+
+const { remoteMcpMiddleware } = await import("../../lib/agents/middleware/remote-mcp.js")
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMcpConfig(toolFilter) {
+  return {
+    _mcpDynamic: true,
+    mcpUrl: "http://mock-mcp/mcp",
+    serviceName: "testservice",
+    resolveHeaders: async () => ({}),
+    toolFilter,
+  }
+}
+
+function makeFakeTools(...names) {
+  return names.map((name) => ({ name, invoke: vi.fn(), schema: { type: "object" } }))
+}
+
+async function resolveTools(toolFilter) {
+  const mcpConfig = makeMcpConfig(toolFilter)
+  // Set up cds.context and invoke wrapModelCall
+  cds.context = { __mcpDynamicTools: {} }
+  mockGetTools.mockResolvedValueOnce(makeFakeTools("query", "describe", "insert"))
+
+  let capturedTools
+  const middleware = remoteMcpMiddleware()
+  await middleware.wrapModelCall(
+    { tools: [mcpConfig] }, // MCP placeholder — resolved and filtered by the middleware
+    (req) => {
+      capturedTools = req.tools
+      return {}
+    },
+  )
+  return capturedTools
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("remoteMcpMiddleware — mcp.tools filter", () => {
+  beforeEach(() => {
+    mockGetTools.mockReset()
+    cds.context = {}
+  })
+
+  it("returns all tools when no toolFilter is set", async () => {
+    const tools = await resolveTools(undefined)
+    const names = tools.map((t) => t.name)
+    expect(names).toContain("testservice_query")
+    expect(names).toContain("testservice_describe")
+    expect(names).toContain("testservice_insert")
+  })
+
+  it("returns all tools when toolFilter is an empty array", async () => {
+    const tools = await resolveTools([])
+    expect(tools.length).toBe(3)
+  })
+
+  it("filters to only the specified tools (exact match)", async () => {
+    const tools = await resolveTools(["query", "describe"])
+    const names = tools.map((t) => t.name)
+    expect(names).toEqual(["testservice_query", "testservice_describe"])
+    expect(names).not.toContain("testservice_insert")
+  })
+
+  it("returns empty array when none of the specified tools exist", async () => {
+    const tools = await resolveTools(["nonexistent"])
+    expect(tools).toHaveLength(0)
+  })
+
+  it("filter matches raw MCP tool names, not the prefixed names", async () => {
+    // "query" is the raw name; "testservice_query" is the prefixed name exposed to the agent.
+    // The filter must be specified using raw names (as declared in the MCP server).
+    const withRawName = await resolveTools(["query"])
+    expect(withRawName.map((t) => t.name)).toContain("testservice_query")
+
+    const withPrefixedName = await resolveTools(["testservice_query"])
+    expect(withPrefixedName).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Enable remote MCP tool filtering

**Category:** New Feature ✨

### Summary

Adds support for restricting exposed tools from remote MCP servers via `cds.requires.<service>.mcp.tools`.

### Changes

- Remote MCP tool placeholders now carry an optional `toolFilter` from service configuration.
- `remoteMcpMiddleware` filters tools returned by `MultiServerMCPClient#getTools()` before applying the service-name prefix.
- Filtering uses the raw MCP tool names as declared by the MCP server, not the prefixed names exposed to the agent.
- Added integration-style tests covering:
  - no filter configured
  - empty filter arrays
  - exact raw-name filtering
  - unknown tool names
  - raw vs prefixed tool-name behavior
- Added a changelog entry for the new remote MCP filtering capability.

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- Correlation ID: `aaaf4370-add8-11f1-9628-f1558d77bcc2`
- LLM: `gpt-5.5`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
