### PR TITLE
fix: mask api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Services with `@protocol: 'agent'` now also register `@agent` specific handlers
+- Mask apiKey in debug logs read from claude / opencode settings
 
 ## Version 0.9.4 - 2026-09-10
 

--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -38,6 +38,10 @@ export default class ChatAnthropicService extends ChatAnthropic {
   }
 }
 
+function maskApiKey(conf) {
+  return { ...conf, apiKey: conf.apiKey? '***' : undefined}
+}
+
 function fromEnv (env = process.env, silent) {
   let any, config = {}
   if ((any = env.ANTHROPIC_BASE_URL)) config.anthropicApiUrl = any
@@ -45,7 +49,7 @@ function fromEnv (env = process.env, silent) {
   if ((any = env.ANTHROPIC_API_KEY)) config.apiKey = any
   if ((any = env.ANTHROPIC_MODEL)) config.model = any
   if (!Object.keys(config).length) return null
-  if (!silent) LOG.debug (`Loaded Anthropic settings from env:`, config)
+  if (!silent) LOG.debug (`Loaded Anthropic settings from env:`, maskApiKey(config))
   return config
 }
 
@@ -61,7 +65,7 @@ function fromClaude() {
       let family = (settings.model||'sonnet').toUpperCase()
       conf.model = settings.env[`ANTHROPIC_DEFAULT_${family}_MODEL`] || settings?.model
     }
-    LOG.debug(`Loaded Claude settings from`, local(settings_json), ':', conf)
+    LOG.debug(`Loaded Claude settings from`, local(settings_json), ':', maskApiKey(conf))
   } catch {
     LOG.debug(`Failed loading Claude settings from`, local(settings_json))
     fromClaude.cached = null
@@ -74,7 +78,6 @@ function fromOpencode() {
   const opencode_json = path.join (HOME,'.config/opencode/opencode.json')
   try {
     let conf = JSON.parse (fs.readFileSync (opencode_json,'utf8'))
-    LOG.debug(`Loaded OpenCode settings from`, local(opencode_json))
     // https://opencode.ai/config.json
     let o = conf?.provider?.anthropic?.options
     if (!o) return fromOpencode.cached = null
@@ -83,7 +86,7 @@ function fromOpencode() {
     if ((any = o.anthropicApiKey ?? o.apiKey)) config.apiKey = any
     if ((any = conf?.model)) config.model = any.replace('anthropic/','')
     fromOpencode.cached = Object.keys(config).length ? config : null
-    LOG.debug(`Loaded OpenCode settings from`, local(opencode_json), ':', conf)
+    LOG.debug(`Loaded OpenCode settings from`, local(opencode_json), ':', maskApiKey(config))
   } catch {
     LOG.debug(`Failed loading OpenCode settings from`, local(opencode_json))
     fromOpencode.cached = null


### PR DESCRIPTION
Mask all api key occurrences in debug logs while loading the anthropic provider. Introduced with #99 

### Have you...

- [x] Added relevant entry to the change log?
